### PR TITLE
Fix missing db alias

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,2 @@
+export * from './models/db';
+


### PR DESCRIPTION
## Summary
- add `src/lib/db.ts` to re-export database helpers and satisfy alias `@/lib/db`

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f9bfd58fc8325a0ebd4db358cdcf5