### PR TITLE
Fix TestModeIndicator overlap

### DIFF
--- a/src/components/ui/TestModeIndicator.tsx
+++ b/src/components/ui/TestModeIndicator.tsx
@@ -8,8 +8,11 @@ export default function TestModeIndicator() {
   if (!isTestMode) return null;
 
   return (
-    <div className="fixed top-0 left-0 right-0 bg-amber-500 text-white text-center py-2 text-sm font-semibold z-50">
-      🧪 TEST MODE - Use test cards: 4242 4242 4242 4242
-    </div>
+    <>
+      <div className="fixed top-0 left-0 right-0 bg-amber-500 text-white text-center py-2 text-sm font-semibold z-50">
+        🧪 TEST MODE - Use test cards: 4242 4242 4242 4242
+      </div>
+      <div className="h-10" />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- push down site navigation when the test mode banner appears

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846533cb94c8325b2c53e89499f49a2