### PR TITLE
Fix dynamic route params access

### DIFF
--- a/src/app/api/auth/profile/[id]/route.ts
+++ b/src/app/api/auth/profile/[id]/route.ts
@@ -14,7 +14,7 @@ export const GET = withAuth(async (
 ) => {
   await connectDB();
   
-  const userId = params.id;
+  const { id: userId } = await params;
 
   // Verify the user ID matches the session
   if (userId !== session.user.id) {

--- a/src/app/api/professional/[id]/route.ts
+++ b/src/app/api/professional/[id]/route.ts
@@ -10,7 +10,7 @@ export const GET = withDB(async (
   request: NextRequest,
   { params }: { params: { id: string } }
 ) => {
-  const professionalId = params.id;
+  const { id: professionalId } = await params;
 
   if (!professionalId) {
     return errorResponse('Professional ID is required', 400);

--- a/src/app/api/sessions/[id]/confirm/route.ts
+++ b/src/app/api/sessions/[id]/confirm/route.ts
@@ -17,7 +17,7 @@ interface ConfirmSessionRequest {
  * Professional accepts or declines a session request
  */
 export const POST = withAuthAndDB(async (request: NextRequest, { params }: { params: { id: string } }, session: any) => {
-  const sessionId = params.id;
+  const { id: sessionId } = await params;
   
   // Validate request body
   const validation = await validateRequestBody<ConfirmSessionRequest>(request, [
@@ -199,7 +199,7 @@ export const POST = withAuthAndDB(async (request: NextRequest, { params }: { par
  * Get session details for confirmation
  */
 export const GET = withAuthAndDB(async (request: NextRequest, { params }: { params: { id: string } }, session: any) => {
-  const sessionId = params.id;
+  const { id: sessionId } = await params;
   const { searchParams } = new URL(request.url);
   const professionalId = searchParams.get('professionalId');
 

--- a/src/app/api/sessions/candidate/[id]/route.ts
+++ b/src/app/api/sessions/candidate/[id]/route.ts
@@ -11,7 +11,7 @@ export const GET = withAuthAndDB(async (
   { params }: { params: { id: string } },
   session: any
 ) => {
-  const candidateId = params.id;
+  const { id: candidateId } = await params;
 
   if (!candidateId) {
     return errorResponse('Candidate ID is required', 400);


### PR DESCRIPTION
## Summary
- await dynamic params in profile and sessions API handlers

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6846577c4e488325986cb1ec81466b0f