### PR TITLE
Fix dynamic API params usage

### DIFF
--- a/src/app/api/auth/profile/[id]/route.ts
+++ b/src/app/api/auth/profile/[id]/route.ts
@@ -13,9 +13,9 @@ export const GET = withAuth(async (
   { params }: { params: { id: string } },
   session: Session
 ) => {
-  await connectDB();
-  
   const { id: userId } = params;
+
+  await connectDB();
 
   // Verify the user ID matches the session
   if (userId !== session.user.id) {


### PR DESCRIPTION
## Summary
- fix `/api/auth/profile/[id]` to extract params before `connectDB`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d606122b48325b8d9d2966cbf6b8a