### PR TITLE
Fix build issues from missing nextauth route

### DIFF
--- a/src/app/api/auth/complete-profile/route.ts
+++ b/src/app/api/auth/complete-profile/route.ts
@@ -41,7 +41,7 @@ interface CompleteProfileRequest {
  * POST /api/auth/complete-profile
  * Complete user profile after role selection
  */
-export const POST = withAuth(async (request: NextRequest, context: Record<string, unknown>, session: Session) => {
+export const POST = withAuth(async (request: NextRequest, context, session: Session) => {
   await connectDB();
   
   // Validate request body

--- a/src/app/api/auth/profile/[id]/route.ts
+++ b/src/app/api/auth/profile/[id]/route.ts
@@ -10,10 +10,12 @@ import User from '@/lib/models/User';
  */
 export const GET = withAuth(async (
   request: NextRequest,
-  { params }: { params: { id: string } },
+  context: unknown,
   session: Session
 ) => {
-  const { id: userId } = params;
+  const ctx = context as { params?: Promise<Record<string, string | string[] | undefined>> };
+  const params = ctx.params ? await ctx.params : undefined;
+  const userId = (params as Record<string, string | undefined> | undefined)?.id as string;
 
   await connectDB();
 

--- a/src/app/api/auth/setup/route.ts
+++ b/src/app/api/auth/setup/route.ts
@@ -13,7 +13,7 @@ interface SetupRequest {
  * POST /api/auth/setup
  * Set user role after OAuth authentication
  */
-export const POST = withAuth(async (request: NextRequest, context: Record<string, unknown>, session: Session) => {
+export const POST = withAuth(async (request: NextRequest, context, session: Session) => {
   await connectDB();
   
   // Validate request body

--- a/src/app/api/feedback/professional/route.ts
+++ b/src/app/api/feedback/professional/route.ts
@@ -31,7 +31,7 @@ interface SubmitFeedbackRequest {
  * POST /api/feedback/professional
  * Submit professional feedback and trigger session fee + referral payouts
  */
-export const POST = withAuthAndDB(async (request: NextRequest, context: Record<string, unknown>, session: AuthSession) => {
+export const POST = withAuthAndDB(async (request: NextRequest, context, session: AuthSession) => {
   // Validate request body
   const validation = await validateRequestBody<SubmitFeedbackRequest>(request, [
     'sessionId', 'professionalId', 'culturalFitRating', 'interestRating', 

--- a/src/app/api/professional/[id]/route.ts
+++ b/src/app/api/professional/[id]/route.ts
@@ -6,11 +6,13 @@ import Session from '@/lib/models/Session';
  * GET /api/professional/[id]
  * Fetch all sessions for a professional with earnings calculation
  */
-export const GET = withDB<{ params: { id: string } }>(async (
+export const GET = withDB(async (
   request: NextRequest,
-  { params }: { params: { id: string } }
+  context: unknown
 ) => {
-  const { id: professionalId } = params;
+  const ctx = context as { params?: Promise<Record<string, string | string[] | undefined>> };
+  const params = ctx.params ? await ctx.params : undefined;
+  const professionalId = (params as Record<string, string | undefined> | undefined)?.id as string;
 
   if (!professionalId) {
     return errorResponse('Professional ID is required', 400);

--- a/src/app/api/profile/switch-role/route.ts
+++ b/src/app/api/profile/switch-role/route.ts
@@ -13,7 +13,7 @@ interface SwitchRoleRequest {
  * POST /api/profile/switch-role
  * Switch user role between candidate and professional
  */
-export const POST = withAuth(async (request: NextRequest, context: Record<string, unknown>, session: Session) => {
+export const POST = withAuth(async (request: NextRequest, context, session: Session) => {
   await connectDB();
   
   // Validate request body
@@ -83,7 +83,7 @@ export const POST = withAuth(async (request: NextRequest, context: Record<string
  * GET /api/profile/switch-role
  * Get role switching information for the current user
  */
-export const GET = withAuth(async (request: NextRequest, context: Record<string, unknown>, session: Session) => {
+export const GET = withAuth(async (request: NextRequest, context, session: Session) => {
   await connectDB();
   
   const userId = session.user.id;

--- a/src/app/api/profile/update/route.ts
+++ b/src/app/api/profile/update/route.ts
@@ -37,7 +37,7 @@ interface UpdateProfileRequest {
  * PUT /api/profile/update
  * Update user profile information
  */
-export const PUT = withAuth(async (request: NextRequest, context: Record<string, unknown>, session: Session) => {
+export const PUT = withAuth(async (request: NextRequest, context, session: Session) => {
   await connectDB();
   
   // Validate request body

--- a/src/app/api/sessions/[id]/confirm/route.ts
+++ b/src/app/api/sessions/[id]/confirm/route.ts
@@ -17,12 +17,14 @@ interface ConfirmSessionRequest {
  * POST /api/sessions/[id]/confirm
  * Professional accepts or declines a session request
  */
-export const POST = withAuthAndDB<{ params: { id: string } }>(async (
+export const POST = withAuthAndDB(async (
   request: NextRequest,
-  { params }: { params: { id: string } },
+  context: unknown,
   session: AuthSession
 ): Promise<NextResponse> => {
-  const { id: sessionId } = params;
+  const ctx = context as { params?: Promise<Record<string, string | string[] | undefined>> };
+  const params = ctx.params ? await ctx.params : undefined;
+  const sessionId = (params as Record<string, string | undefined> | undefined)?.id as string;
   
   // Validate request body
   const validation = await validateRequestBody<ConfirmSessionRequest>(request, [
@@ -204,12 +206,14 @@ export const POST = withAuthAndDB<{ params: { id: string } }>(async (
  * GET /api/sessions/[id]/confirm
  * Get session details for confirmation
  */
-export const GET = withAuthAndDB<{ params: { id: string } }>(async (
+export const GET = withAuthAndDB(async (
   request: NextRequest,
-  { params }: { params: { id: string } },
+  context: unknown,
   session: AuthSession
 ): Promise<NextResponse> => {
-  const { id: sessionId } = params;
+  const ctx = context as { params?: Promise<Record<string, string | string[] | undefined>> };
+  const params = ctx.params ? await ctx.params : undefined;
+  const sessionId = (params as Record<string, string | undefined> | undefined)?.id as string;
   const { searchParams } = new URL(request.url);
   const professionalId = searchParams.get('professionalId');
 

--- a/src/app/api/sessions/book/route.ts
+++ b/src/app/api/sessions/book/route.ts
@@ -26,7 +26,7 @@ interface BookSessionRequest {
  * POST /api/sessions/book
  * Books a session and creates Stripe PaymentIntent
  */
-export const POST = withAuthAndDB(async (request: NextRequest, context: Record<string, unknown>, session: AuthSession) => {
+export const POST = withAuthAndDB(async (request: NextRequest, context: unknown, session: AuthSession) => {
   // Validate request body
   const validation = await validateRequestBody<BookSessionRequest>(request, [
     'candidateId', 'professionalId', 'scheduledAt'

--- a/src/app/api/sessions/candidate/[id]/route.ts
+++ b/src/app/api/sessions/candidate/[id]/route.ts
@@ -7,12 +7,14 @@ import type { Session as AuthSession } from 'next-auth';
  * GET /api/sessions/candidate/[id]
  * Fetch all sessions for a candidate
  */
-export const GET = withAuthAndDB<{ params: { id: string } }>(async (
+export const GET = withAuthAndDB(async (
   request: NextRequest,
-  { params }: { params: { id: string } },
+  context: unknown,
   session: AuthSession
 ) => {
-  const { id: candidateId } = params;
+  const ctx = context as { params?: Promise<Record<string, string | string[] | undefined>> };
+  const params = ctx.params ? await ctx.params : undefined;
+  const candidateId = (params as Record<string, string | undefined> | undefined)?.id as string;
 
   if (!candidateId) {
     return errorResponse('Candidate ID is required', 400);

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -51,7 +51,6 @@ export async function POST(request: NextRequest) {
         await handleTransferCreated(event.data.object as Stripe.Transfer);
         break;
 
-
       case 'account.updated':
         await handleAccountUpdated(event.data.object as Stripe.Account);
         break;
@@ -150,19 +149,6 @@ async function handleTransferCreated(transfer: Stripe.Transfer) {
   // For session fees, the payout status is already updated in the feedback API
   // For referral bonuses, the ReferralEdge records are already created
   // This webhook mainly serves as a confirmation/audit trail
-}
-
-/**
- * Handle transfer failure - needs manual intervention
- */
-async function handleTransferFailed(transfer: Stripe.Transfer) {
-  const sessionId = transfer.metadata.sessionId;
-  const transferType = transfer.metadata.type;
-
-  console.error(`Transfer failed: ${transfer.id} for session ${sessionId} (${transferType})`);
-
-  // TODO: Implement retry logic or manual intervention workflow
-  // For now, just log the failure for manual review
 }
 
 /**

--- a/src/app/auth/setup/candidate/page.tsx
+++ b/src/app/auth/setup/candidate/page.tsx
@@ -60,7 +60,7 @@ export default function CandidateProfilePage() {
     if (!session?.user?.id) return;
 
     try {
-      const result = await apiRequest<any>(
+      const result = await apiRequest<CandidateProfile>(
         `/api/auth/profile/${session.user.id}`
       );
       if (result.success && result.data) {

--- a/src/app/auth/setup/professional/page.tsx
+++ b/src/app/auth/setup/professional/page.tsx
@@ -89,14 +89,14 @@ export default function ProfessionalProfilePage() {
     if (!session?.user?.id) return;
 
     try {
-      const result = await apiRequest<any>(
+      const result = await apiRequest<ProfessionalProfile>(
         `/api/auth/profile/${session.user.id}`
       );
       if (result.success && result.data) {
         setProfile(prev => ({
           ...prev,
           ...(result.data as Partial<ProfessionalProfile>),
-          expertise: (result.data as any).expertise || []
+          expertise: result.data?.expertise || []
         }));
       }
     } catch (error) {

--- a/src/lib/api/error-handler.ts
+++ b/src/lib/api/error-handler.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+type RouteContext = unknown;
 import { getServerSession } from 'next-auth/next';
 import type { Session } from 'next-auth';
 import { authOptions } from '@/lib/auth';
@@ -19,11 +20,11 @@ export function successResponse<T>(data: T, message?: string) {
 }
 
 // Authentication wrapper
-export function withAuth<T extends Record<string, unknown>>(
-  handler: (request: NextRequest, context: T, session: Session) => Promise<NextResponse>,
+export function withAuth(
+  handler: (request: NextRequest, context: RouteContext, session: Session) => Promise<NextResponse>,
   options: { requireRole?: 'candidate' | 'professional' } = {}
 ) {
-  return async (request: NextRequest, context: T) => {
+  return async (request: NextRequest, context: RouteContext) => {
     try {
       const session = await getServerSession(authOptions);
       
@@ -44,10 +45,10 @@ export function withAuth<T extends Record<string, unknown>>(
 }
 
 // Database connection wrapper
-export function withDB<T extends Record<string, unknown>>(
-  handler: (request: NextRequest, context: T) => Promise<NextResponse>
+export function withDB(
+  handler: (request: NextRequest, context: RouteContext) => Promise<NextResponse>
 ) {
-  return async (request: NextRequest, context: T) => {
+  return async (request: NextRequest, context: RouteContext) => {
     try {
       await connectDB();
       return await handler(request, context);
@@ -59,18 +60,18 @@ export function withDB<T extends Record<string, unknown>>(
 }
 
 // Combined wrapper for auth + DB
-export function withAuthAndDB<T extends Record<string, unknown>>(
-  handler: (request: NextRequest, context: T, session: Session) => Promise<NextResponse>,
+export function withAuthAndDB(
+  handler: (request: NextRequest, context: RouteContext, session: Session) => Promise<NextResponse>,
   options: { requireRole?: 'candidate' | 'professional' } = {}
 ) {
   return withDB(withAuth(handler, options));
 }
 
 // Error handling wrapper
-export function withErrorHandling<T extends Record<string, unknown>>(
-  handler: (request: NextRequest, context: T) => Promise<NextResponse>
+export function withErrorHandling(
+  handler: (request: NextRequest, context: RouteContext) => Promise<NextResponse>
 ) {
-  return async (request: NextRequest, context: T) => {
+  return async (request: NextRequest, context: RouteContext) => {
     try {
       return await handler(request, context);
     } catch (error) {


### PR DESCRIPTION
## Summary
- clean up unused Stripe webhook code
- adjust auth API routes to type context generically
- ensure profile APIs compile without implicit `any`
- update professional setup page to avoid optional errors
- allow booking and session routes to accept untyped context

## Testing
- `npm run lint`
- `npm run build` *(fails: STRIPE_SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_684d7385e9b48325bc7d90d0703018ee