### PR TITLE
Fix runtime env checks for Stripe APIs

### DIFF
--- a/src/app/api/auth/complete-profile/route.ts
+++ b/src/app/api/auth/complete-profile/route.ts
@@ -5,9 +5,13 @@ import { connectDB } from '@/lib/models/db';
 import User from '@/lib/models/User';
 import Stripe from 'stripe';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2023-10-16'
-});
+function getStripe() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error('STRIPE_SECRET_KEY environment variable is required');
+  }
+  return new Stripe(key, { apiVersion: '2023-10-16' });
+}
 
 interface CompleteProfileRequest {
   userId: string;
@@ -138,6 +142,7 @@ export const POST = withAuth(async (request: NextRequest, context, session: Sess
     }
 
     // Create Stripe Connect account for professional
+    const stripe = getStripe();
     try {
       const stripeAccount = await stripe.accounts.create({
         type: 'express',

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -4,11 +4,21 @@ import Stripe from 'stripe';
 import { connectDB } from '@/lib/models/db';
 import Session from '@/lib/models/Session';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2023-10-16'
-});
+function getStripe() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error('STRIPE_SECRET_KEY environment variable is required');
+  }
+  return new Stripe(key, { apiVersion: '2023-10-16' });
+}
 
-const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
+function getWebhookSecret() {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) {
+    throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
+  }
+  return secret;
+}
 
 /**
  * POST /api/webhooks/stripe
@@ -16,6 +26,8 @@ const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
  */
 export async function POST(request: NextRequest) {
   try {
+    const stripe = getStripe();
+    const webhookSecret = getWebhookSecret();
     const body = await request.text();
     const headersList = await headers();
     const signature = headersList.get('stripe-signature');


### PR DESCRIPTION
## Summary
- avoid top-level Stripe initialization so builds don't fail without env vars
- use helper functions to fetch Stripe secret and webhook secret

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d8c676c848325bfebb47234e5cae8