### PR TITLE
Fix pending chats display

### DIFF
--- a/src/app/api/sessions/candidate/[id]/route.ts
+++ b/src/app/api/sessions/candidate/[id]/route.ts
@@ -27,11 +27,11 @@ export const GET = withAuthAndDB(async (
 
   const now = new Date();
 
-  // Fetch upcoming sessions (requested or confirmed, in the future)
+  // Fetch upcoming sessions (only confirmed and still in the future)
   const upcomingSessions = await Session.find({
     candidateId,
     scheduledAt: { $gte: now },
-    status: { $in: ['requested', 'confirmed'] }
+    status: 'confirmed'
   })
   .populate('professionalId', 'name title company profileImageUrl')
   .sort({ scheduledAt: 1 })


### PR DESCRIPTION
## Summary
- show pending chat requests on candidate dashboard
- return only confirmed sessions as `upcoming`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*
- `npm run build` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_684ed48277ec8325bef4cd2817cdc6d5