### PR TITLE
Handle nested API success structure

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -267,8 +267,16 @@ export async function apiRequest<T>(
     if (!response.ok) {
       return {
         success: false,
-        error: data.error || `HTTP ${response.status}: ${response.statusText}`
+        error: data?.error || `HTTP ${response.status}: ${response.statusText}`
       };
+    }
+
+    // Some API routes return { success: boolean, data: T }
+    if (typeof data === 'object' && data !== null && 'success' in data) {
+      if (data.success) {
+        return { success: true, data: data.data as T };
+      }
+      return { success: false, error: data.error as string };
     }
 
     return { success: true, data };


### PR DESCRIPTION
## Summary
- handle nested success/data responses in `apiRequest`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f076acb688325a009198d915c46ba