### PR TITLE
Fix session fetch for candidate dashboard

### DIFF
--- a/src/app/components/EnhancedCandidateDashboard.tsx
+++ b/src/app/components/EnhancedCandidateDashboard.tsx
@@ -162,7 +162,7 @@ export default function EnhancedCandidateDashboard() {
       !filters.industry &&
       !filters.company &&
       !filters.expertise &&
-      filters.maxRate === 1000 &&
+      filters.maxRate === 10000 &&
       filters.minExperience === 0;
 
     if (noFilters) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -249,7 +249,7 @@ export function createDebouncedSearch<T>(
  * Common API fetch wrapper with error handling
  */
 export async function apiRequest<T>(
-  url: string, 
+  url: string,
   options: RequestInit = {}
 ): Promise<{ success: boolean; data?: T; error?: string }> {
   try {
@@ -258,6 +258,7 @@ export async function apiRequest<T>(
         'Content-Type': 'application/json',
         ...options.headers,
       },
+      credentials: 'include',
       ...options,
     });
 


### PR DESCRIPTION
## Summary
- ensure credentials are included for fetch helpers
- correct filter condition for professionals list

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*
- `npm run build` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_684f1a837d648325a1089213367222fa