### PR TITLE
Fix role switch session update

### DIFF
--- a/src/app/profile/switch-role/page.tsx
+++ b/src/app/profile/switch-role/page.tsx
@@ -10,7 +10,7 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import Navigation from '@/components/ui/Navigation';
 
 export default function SwitchRolePage() {
-  const { data: session } = useSession();
+  const { data: session, update: updateSession } = useSession();
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [newRole, setNewRole] = useState<'candidate' | 'professional' | ''>('');
@@ -41,6 +41,12 @@ export default function SwitchRolePage() {
       });
       
       if (result.success) {
+        // Update NextAuth session with the new role
+        try {
+          await updateSession({ role: targetRole, profileComplete: false });
+        } catch (err) {
+          console.warn('Failed to update session', err);
+        }
         // Redirect to profile completion for the new role
         router.push(`/auth/setup/${targetRole}`);
       } else {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -78,7 +78,16 @@ export const authOptions: NextAuthOptions = {
       }
     },
 
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
+      if (trigger === 'update' && session) {
+        if (session.role) {
+          token.role = session.role as string;
+        }
+        if (typeof session.profileComplete !== 'undefined') {
+          token.profileComplete = session.profileComplete as boolean;
+        }
+      }
+
       if (user) {
         try {
           await connectDB();


### PR DESCRIPTION
## Summary
- update JWT callback to handle session updates
- refresh NextAuth session when switching roles

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f303c24c08325bf385506dccb26de