### PR TITLE
Fix profile switch redirect path

### DIFF
--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -34,8 +34,8 @@ export function useAuthGuard(options: AuthGuardOptions = {}): AuthGuardReturn {
     redirectTo = {
       noAuth: '/auth/signin',
       noRole: '/auth/setup',
-      wrongRole: requiredRole === 'candidate' ? '/professional/dashboard' : '/candidate/dashboard',
-      incompleteProfile: requiredRole === 'candidate' ? '/auth/setup/candidate' : '/auth/setup/professional'
+      wrongRole: requiredRole === 'candidate' ? '/professional/dashboard' : '/candidate/dashboard'
+      // incompleteProfile handled dynamically based on current role
     }
   } = options;
 
@@ -67,7 +67,10 @@ export function useAuthGuard(options: AuthGuardOptions = {}): AuthGuardReturn {
 
     // Check profile completion
     if (requireProfileComplete && !hasCompleteProfile) {
-      router.push(redirectTo.incompleteProfile!);
+      const incomplete =
+        redirectTo.incompleteProfile ||
+        `/auth/setup/${session.user?.role ?? 'candidate'}`;
+      router.push(incomplete);
       return;
     }
   }, [


### PR DESCRIPTION
## Summary
- fix redirect logic in `useAuthGuard` so incomplete profile pages respect the user's role

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f3bfe7a7883259cabd04172cab68d