### PR TITLE
Fix calendar availability grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ stacks/
 
 ## 🔄 Calendar Integration
 
-### Google Calendar Sync
-- **OAuth scope**: `https://www.googleapis.com/auth/calendar.events`
+-### Google Calendar Sync
+- **OAuth scope**: `https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly`
 - **Free/busy queries** for availability checking
 - **Automatic event creation** for confirmed sessions
 - **Manual availability** editing with override capability

--- a/src/components/ui/AvailabilityGrid.tsx
+++ b/src/components/ui/AvailabilityGrid.tsx
@@ -55,24 +55,27 @@ export default function AvailabilityGrid({ startDate, days, initialSelected, onC
   const maxTime = setHours(setMinutes(startOfDay(new Date()), 0), 20);
   const maxDate = addDays(startDate, days - 1);
 
-  const handleSelectSlot = ({ start }: SlotInfo) => {
-    const rounded = setMinutes(start, start.getMinutes() < 30 ? 0 : 30);
-    const iso = new Date(rounded.setSeconds(0, 0)).toISOString();
-    const exists = events.find((e) => e.id === iso);
-    let next: AvailabilityEvent[];
-    if (exists) {
-      next = events.filter((e) => e.id !== iso);
-    } else {
-      next = [
-        ...events,
-        {
+  const handleSelectSlot = ({ start, end }: SlotInfo) => {
+    const startRounded = setMinutes(start, start.getMinutes() < 30 ? 0 : 30);
+    const endRounded = setMinutes(end, end.getMinutes() < 30 ? 0 : 30);
+
+    const next = [...events];
+    for (let d = new Date(startRounded); d < endRounded; d = new Date(d.getTime() + 30 * 60000)) {
+      const slot = new Date(d.setSeconds(0, 0));
+      const iso = slot.toISOString();
+      const idx = next.findIndex((e) => e.id === iso);
+      if (idx >= 0) {
+        next.splice(idx, 1);
+      } else {
+        next.push({
           id: iso,
           title: 'Available',
           start: new Date(iso),
           end: new Date(new Date(iso).getTime() + 30 * 60000),
-        },
-      ];
+        });
+      }
     }
+
     setEvents(next);
     onChange?.(new Set(next.map((e) => e.start.toISOString())));
   };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,7 +10,8 @@ export const authOptions: NextAuthOptions = {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
       authorization: {
         params: {
-          scope: 'openid email profile https://www.googleapis.com/auth/calendar.events'
+          scope:
+            'openid email profile https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly'
         }
       }
     }),


### PR DESCRIPTION
## Summary
- add calendar.readonly scope for free/busy API calls
- allow selecting multiple 30min slots in `AvailabilityGrid`
- document new OAuth scope

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f5fd408a083259b6b649f6d3b43ba