### PR TITLE
Ensure role switch keeps users logged in

### DIFF
--- a/src/app/api/auth/complete-profile/route.ts
+++ b/src/app/api/auth/complete-profile/route.ts
@@ -178,7 +178,7 @@ export const POST = withAuth(async (request: NextRequest, context, session: Sess
       const accountLink = await stripe.accountLinks.create({
         account: stripeAccount.id,
         refresh_url: `${process.env.NEXTAUTH_URL}/auth/setup/professional?refresh=true`,
-        return_url: `${process.env.NEXTAUTH_URL}/professional/dashboard`,
+        return_url: `${process.env.NEXTAUTH_URL}/dashboard`,
         type: 'account_onboarding'
       });
 

--- a/src/app/auth/setup/candidate/page.tsx
+++ b/src/app/auth/setup/candidate/page.tsx
@@ -173,7 +173,7 @@ export default function CandidateProfilePage() {
       if (result.success) {
         // Successful submission - redirect to candidate dashboard
         console.log('Profile completed successfully, redirecting to dashboard');
-        router.push('/candidate/dashboard');
+        router.push('/dashboard');
       } else {
         // API returned an error - preserve form state and show error
         const errorMessage = result.error || 'Failed to save profile. Please try again.';

--- a/src/app/auth/setup/page.tsx
+++ b/src/app/auth/setup/page.tsx
@@ -26,10 +26,8 @@ export default function SetupPage() {
   useEffect(() => {
     if (!session?.user?.role) return;
 
-    if (session.user.role === 'candidate') {
-      router.replace('/candidate/dashboard');
-    } else if (session.user.role === 'professional') {
-      router.replace('/professional/dashboard');
+    if (session.user.role === 'candidate' || session.user.role === 'professional') {
+      router.replace('/dashboard');
     }
   }, [session?.user?.role, router]);
 

--- a/src/app/auth/setup/professional/page.tsx
+++ b/src/app/auth/setup/professional/page.tsx
@@ -219,7 +219,7 @@ export default function ProfessionalProfilePage() {
         } else {
           // Redirect to professional dashboard
           console.log('Profile completed successfully, redirecting to dashboard');
-          router.push('/professional/dashboard');
+          router.push('/dashboard');
         }
       } else {
         // API returned an error - preserve form state and show error

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import LoadingSpinner from '@/components/ui/LoadingSpinner';
+
+export default function DashboardRedirectPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === 'loading') return;
+
+    if (!session?.user?.id) {
+      router.replace('/auth/signin');
+      return;
+    }
+
+    if (session.user.role === 'candidate') {
+      router.replace('/candidate/dashboard');
+    } else if (session.user.role === 'professional') {
+      router.replace('/professional/dashboard');
+    } else {
+      router.replace('/auth/setup');
+    }
+  }, [status, session, router]);
+
+  return <LoadingSpinner message="Loading dashboard..." />;
+}

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -806,7 +806,7 @@ export default function ProfileEditPage() {
           {/* Action Buttons */}
           <div className="mt-8 pt-6 border-t border-gray-200 flex justify-between">
             <Link
-              href={isCandidate ? '/candidate/dashboard' : '/professional/dashboard'}
+              href="/dashboard"
               className="px-6 py-2.5 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 font-medium transition-colors"
             >
               Cancel

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -57,8 +57,8 @@ export default function Navigation({
       return (
         <div className="flex items-center space-x-4">
           {showDashboardLink && (
-            <Link 
-              href={variant === 'candidate' ? '/candidate/dashboard' : '/professional/dashboard'}
+            <Link
+              href="/dashboard"
               className="text-gray-600 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium"
             >
               Dashboard
@@ -76,7 +76,7 @@ export default function Navigation({
           
           {variant === 'professional' && (
             <Link
-              href="/professional/dashboard#candidates"
+              href="/dashboard#candidates"
               className="text-gray-600 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium"
             >
               Browse Candidates


### PR DESCRIPTION
## Summary
- add a `/dashboard` route that forwards users to their role-specific dashboard
- update navigation and setup pages to use the new dashboard redirect
- keep dashboard link functional after role changes
- adjust Stripe complete-profile return URL

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f6c8ea20c83258671a914df255d4f