### PR TITLE
fix: improve role switch lookup

### DIFF
--- a/src/app/api/profile/switch-role/route.ts
+++ b/src/app/api/profile/switch-role/route.ts
@@ -35,8 +35,16 @@ export const POST = withAuth(async (request: NextRequest, context, session: Sess
     return errorResponse('Invalid role', 400);
   }
 
-  // Get user
-  const user = await User.findById(userId);
+  // Get user by id; fallback to email in case session id is stale
+  let user = await User.findById(userId);
+  if (!user && session.user.email) {
+    user = await User.findOne({ email: session.user.email });
+    if (user) {
+      console.warn(
+        `User id ${userId} not found, falling back to email ${session.user.email}`
+      );
+    }
+  }
   if (!user) {
     return errorResponse('User not found', 404);
   }
@@ -86,8 +94,11 @@ export const GET = withAuth(async (request: NextRequest, context, session: Sessi
   
   const userId = session.user.id;
   
-  // Get user
-  const user = await User.findById(userId);
+  // Get user by id; fallback to email
+  let user = await User.findById(userId);
+  if (!user && session.user.email) {
+    user = await User.findOne({ email: session.user.email });
+  }
   if (!user) {
     return errorResponse('User not found', 404);
   }


### PR DESCRIPTION
## Summary
- ensure user lookup falls back to email if session user ID is stale when switching roles

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f6fcab6a48325b52d53048ddbcfa3