### PR TITLE
Fix TypeScript errors in dashboard components

### DIFF
--- a/src/app/components/EnhancedCandidateDashboard.tsx
+++ b/src/app/components/EnhancedCandidateDashboard.tsx
@@ -26,7 +26,7 @@ interface Professional {
 
 interface Session {
   _id: string;
-  professionalId: string;
+  professionalId: string | Professional;
   scheduledAt: string;
   durationMinutes: number;
   rateCents: number;
@@ -297,23 +297,37 @@ export default function EnhancedCandidateDashboard() {
                     <div key={sessionItem._id} className="px-6 py-3 hover:bg-gray-50 transition-colors">
                       <div className="flex items-center space-x-4">
                         {(() => {
-                          const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                          const pro =
+                            sessionItem.professional ||
+                            sessionItem.professionalId ||
+                            sessionItem.professionalIdInfo;
+                          const proObj = typeof pro === 'string' ? undefined : pro;
                           return (
-                            <div className={`w-10 h-10 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                              {pro?.profileImageUrl ? (
-                                <img src={pro.profileImageUrl} alt={pro.name} className="w-10 h-10 rounded-full object-cover" />
+                            <div
+                              className={`w-10 h-10 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}
+                            >
+                              {proObj?.profileImageUrl ? (
+                                <img
+                                  src={proObj.profileImageUrl}
+                                  alt={proObj.name}
+                                  className="w-10 h-10 rounded-full object-cover"
+                                />
                               ) : (
-                                pro?.name?.charAt(0) || '?'
+                                proObj?.name?.charAt(0) || (typeof pro === 'string' ? pro.charAt(0) : '?')
                               )}
                             </div>
                           );
                         })()}
                         <div>
                           {(() => {
-                            const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                            const pro =
+                              sessionItem.professional ||
+                              sessionItem.professionalId ||
+                              sessionItem.professionalIdInfo;
+                            const proObj = typeof pro === 'string' ? undefined : pro;
                             return (
                               <>
-                                <h4 className="font-medium text-gray-900 text-sm">{pro?.name || 'Unknown'}</h4>
+                                <h4 className="font-medium text-gray-900 text-sm">{proObj?.name || (typeof pro === 'string' ? pro : 'Unknown')}</h4>
                                 <p className="text-xs text-gray-600">{formatDate(sessionItem.scheduledAt)}</p>
                               </>
                             );
@@ -352,17 +366,23 @@ export default function EnhancedCandidateDashboard() {
                       <div className="flex items-center justify-between">
                         <div className="flex items-center space-x-4">
                           {(() => {
-                            const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                            const pro =
+                              sessionItem.professional ||
+                              sessionItem.professionalId ||
+                              sessionItem.professionalIdInfo;
+                            const proObj = typeof pro === 'string' ? undefined : pro;
                             return (
-                              <div className={`w-12 h-12 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                                {pro?.profileImageUrl ? (
+                              <div
+                                className={`w-12 h-12 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}
+                              >
+                                {proObj?.profileImageUrl ? (
                                   <img
-                                    src={pro.profileImageUrl}
-                                    alt={pro.name}
+                                    src={proObj.profileImageUrl}
+                                    alt={proObj.name}
                                     className="w-12 h-12 rounded-full object-cover"
                                   />
                                 ) : (
-                                  pro?.name?.charAt(0) || '?'
+                                  proObj?.name?.charAt(0) || (typeof pro === 'string' ? pro.charAt(0) : '?')
                                 )}
                               </div>
                             );
@@ -370,14 +390,18 @@ export default function EnhancedCandidateDashboard() {
 
                           <div>
                             {(() => {
-                              const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                              const pro =
+                                sessionItem.professional ||
+                                sessionItem.professionalId ||
+                                sessionItem.professionalIdInfo;
+                              const proObj = typeof pro === 'string' ? undefined : pro;
                               return (
                                 <>
                                   <h3 className="font-bold text-gray-900">
-                                    {pro?.name || 'Unknown'}
+                                    {proObj?.name || (typeof pro === 'string' ? pro : 'Unknown')}
                                   </h3>
                                   <p className="text-sm text-gray-600">
-                                    {pro?.title} at {pro?.company}
+                                    {proObj?.title} at {proObj?.company}
                                   </p>
                                 </>
                               );

--- a/src/app/components/EnhancedProDashboard.tsx
+++ b/src/app/components/EnhancedProDashboard.tsx
@@ -9,29 +9,26 @@ import Navigation from '@/components/ui/Navigation';
 import CandidateDirectory from '@/app/components/CandidateDirectory';
 import AvailabilityGrid from '@/components/ui/AvailabilityGrid';
 
+interface Candidate {
+  _id: string;
+  name: string;
+  email: string;
+  targetRole?: string;
+  targetIndustry?: string;
+  profileImageUrl?: string;
+}
+
 interface Session {
   _id: string;
-  candidateId: string;
+  candidateId: string | Candidate;
   scheduledAt?: string;
   durationMinutes: number;
   rateCents: number;
   status: 'requested' | 'confirmed' | 'completed' | 'cancelled';
   zoomJoinUrl?: string;
   candidateAvailability?: { start: string; end: string }[];
-  candidate?: {
-    name: string;
-    email: string;
-    targetRole?: string;
-    targetIndustry?: string;
-    profileImageUrl?: string;
-  } | string;
-  candidateIdInfo?: {
-    name: string;
-    email: string;
-    targetRole?: string;
-    targetIndustry?: string;
-    profileImageUrl?: string;
-  } | string;
+  candidate?: Candidate | string;
+  candidateIdInfo?: Candidate | string;
   feedbackSubmittedAt?: string;
   referrerProId?: string;
 }
@@ -241,27 +238,37 @@ export default function EnhancedProDashboard() {
                       <div className="flex justify-between items-center">
                         <div className="flex items-center space-x-3">
                         {(() => {
-                          const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                          const cand =
+                            sessionItem.candidate ||
+                            sessionItem.candidateId ||
+                            sessionItem.candidateIdInfo;
+                          const candObj = typeof cand === 'string' ? undefined : cand;
                           return (
-                            <div className={`w-10 h-10 ${getAvatarGradient(index)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                              {cand?.profileImageUrl ? (
+                            <div
+                              className={`w-10 h-10 ${getAvatarGradient(index)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}
+                            >
+                              {candObj?.profileImageUrl ? (
                                 <img
-                                  src={cand.profileImageUrl}
-                                  alt={cand.name}
+                                  src={candObj.profileImageUrl}
+                                  alt={candObj.name}
                                   className="w-10 h-10 rounded-full object-cover"
                                 />
                               ) : (
-                                cand?.name?.charAt(0) || '?'
+                                candObj?.name?.charAt(0) || (typeof cand === 'string' ? cand.charAt(0) : '?')
                               )}
                             </div>
                           );
                         })()}
                         <div>
                           {(() => {
-                            const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                            const cand =
+                              sessionItem.candidate ||
+                              sessionItem.candidateId ||
+                              sessionItem.candidateIdInfo;
+                            const candObj = typeof cand === 'string' ? undefined : cand;
                             return (
                               <>
-                                <h3 className="font-semibold text-gray-900">{cand?.name || 'Unknown'}</h3>
+                                <h3 className="font-semibold text-gray-900">{candObj?.name || (typeof cand === 'string' ? cand : 'Unknown')}</h3>
                                 <p className="text-sm text-gray-600">{formatDate(sessionItem.scheduledAt || '')}</p>
                               </>
                             );
@@ -331,23 +338,33 @@ export default function EnhancedProDashboard() {
                         <div className="flex justify-between items-center">
                           <div className="flex items-center space-x-3">
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                sessionItem.candidate ||
+                                sessionItem.candidateId ||
+                                sessionItem.candidateIdInfo;
+                              const candObj = typeof cand === 'string' ? undefined : cand;
                               return (
-                                <div className={`w-8 h-8 ${getAvatarGradient(index + 1)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                  {cand?.profileImageUrl ? (
-                                    <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                                <div
+                                  className={`w-8 h-8 ${getAvatarGradient(index + 1)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}
+                                >
+                                  {candObj?.profileImageUrl ? (
+                                    <img src={candObj.profileImageUrl} alt={candObj.name} className="w-8 h-8 rounded-full object-cover" />
                                   ) : (
-                                    cand?.name?.charAt(0) || '?'
+                                    candObj?.name?.charAt(0) || (typeof cand === 'string' ? cand.charAt(0) : '?')
                                   )}
                                 </div>
                               );
                             })()}
                             <div>
                               {(() => {
-                                const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                                const cand =
+                                  sessionItem.candidate ||
+                                  sessionItem.candidateId ||
+                                  sessionItem.candidateIdInfo;
+                                const candObj = typeof cand === 'string' ? undefined : cand;
                                 return (
                                   <>
-                                    <h4 className="font-medium text-gray-900 text-sm">{cand?.name || 'Unknown'}</h4>
+                                    <h4 className="font-medium text-gray-900 text-sm">{candObj?.name || (typeof cand === 'string' ? cand : 'Unknown')}</h4>
                                     <p className="text-xs text-gray-600">{formatDate(sessionItem.scheduledAt || '')}</p>
                                   </>
                                 );
@@ -383,23 +400,33 @@ export default function EnhancedProDashboard() {
                         <div className="flex justify-between items-center">
                           <div className="flex items-center space-x-3">
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                sessionItem.candidate ||
+                                sessionItem.candidateId ||
+                                sessionItem.candidateIdInfo;
+                              const candObj = typeof cand === 'string' ? undefined : cand;
                               return (
-                                <div className={`w-8 h-8 ${getAvatarGradient(index + 2)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                  {cand?.profileImageUrl ? (
-                                    <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                                <div
+                                  className={`w-8 h-8 ${getAvatarGradient(index + 2)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}
+                                >
+                                  {candObj?.profileImageUrl ? (
+                                    <img src={candObj.profileImageUrl} alt={candObj.name} className="w-8 h-8 rounded-full object-cover" />
                                   ) : (
-                                    cand?.name?.charAt(0) || '?'
+                                    candObj?.name?.charAt(0) || (typeof cand === 'string' ? cand.charAt(0) : '?')
                                   )}
                                 </div>
                               );
                             })()}
                             <div>
                               {(() => {
-                                const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                                const cand =
+                                  sessionItem.candidate ||
+                                  sessionItem.candidateId ||
+                                  sessionItem.candidateIdInfo;
+                                const candObj = typeof cand === 'string' ? undefined : cand;
                                 return (
                                   <>
-                                    <h4 className="font-medium text-gray-900 text-sm">{cand?.name || 'Unknown'}</h4>
+                                    <h4 className="font-medium text-gray-900 text-sm">{candObj?.name || (typeof cand === 'string' ? cand : 'Unknown')}</h4>
                                     <p className="text-xs text-gray-600">Referred • {formatDate(sessionItem.scheduledAt || '', false)}</p>
                                   </>
                                 );
@@ -475,23 +502,33 @@ export default function EnhancedProDashboard() {
                       <div className="flex justify-between items-center">
                         <div className="flex items-center space-x-3">
                           {(() => {
-                            const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                            const cand =
+                              sessionItem.candidate ||
+                              sessionItem.candidateId ||
+                              sessionItem.candidateIdInfo;
+                            const candObj = typeof cand === 'string' ? undefined : cand;
                             return (
-                              <div className={`w-8 h-8 ${getAvatarGradient(index + 3)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                {cand?.profileImageUrl ? (
-                                  <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                              <div
+                                className={`w-8 h-8 ${getAvatarGradient(index + 3)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}
+                              >
+                                {candObj?.profileImageUrl ? (
+                                  <img src={candObj.profileImageUrl} alt={candObj.name} className="w-8 h-8 rounded-full object-cover" />
                                 ) : (
-                                  cand?.name?.charAt(0) || '?'
+                                  candObj?.name?.charAt(0) || (typeof cand === 'string' ? cand.charAt(0) : '?')
                                 )}
                               </div>
                             );
                           })()}
                           <div>
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                sessionItem.candidate ||
+                                sessionItem.candidateId ||
+                                sessionItem.candidateIdInfo;
+                              const candObj = typeof cand === 'string' ? undefined : cand;
                               return (
                                 <>
-                                  <h4 className="font-medium text-gray-900">{cand?.name || 'Unknown'}</h4>
+                                  <h4 className="font-medium text-gray-900">{candObj?.name || (typeof cand === 'string' ? cand : 'Unknown')}</h4>
                                   <p className="text-sm text-gray-600">{formatDate(sessionItem.scheduledAt || '', false)}</p>
                                 </>
                               );
@@ -527,24 +564,34 @@ export default function EnhancedProDashboard() {
                       <div className="flex justify-between items-center">
                         <div className="flex items-center space-x-3">
                           {(() => {
-                            const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                            const cand =
+                              sessionItem.candidate ||
+                              sessionItem.candidateId ||
+                              sessionItem.candidateIdInfo;
+                            const candObj = typeof cand === 'string' ? undefined : cand;
                             return (
-                              <div className={`w-8 h-8 ${getAvatarGradient(index + 4)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                {cand?.profileImageUrl ? (
-                                  <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                              <div
+                                className={`w-8 h-8 ${getAvatarGradient(index + 4)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}
+                              >
+                                {candObj?.profileImageUrl ? (
+                                  <img src={candObj.profileImageUrl} alt={candObj.name} className="w-8 h-8 rounded-full object-cover" />
                                 ) : (
-                                  cand?.name?.charAt(0) || '?'
+                                  candObj?.name?.charAt(0) || (typeof cand === 'string' ? cand.charAt(0) : '?')
                                 )}
                               </div>
                             );
                           })()}
                           <div>
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                sessionItem.candidate ||
+                                sessionItem.candidateId ||
+                                sessionItem.candidateIdInfo;
+                              const candObj = typeof cand === 'string' ? undefined : cand;
                               return (
                                 <>
-                                  <h4 className="font-medium text-gray-900">{cand?.name || 'Unknown'}</h4>
-                                  <p className="text-sm text-gray-600">{formatDate(sessionItem.scheduledAt || '', false)} • ${(sessionItem.rateCents / 100).toFixed(0)}</p>
+                                  <h4 className="font-medium text-gray-900">{candObj?.name || (typeof cand === 'string' ? cand : 'Unknown')}</h4>
+                                  <p className="text-sm text-gray-600">{formatDate(sessionItem.scheduledAt || '', false)} • {(sessionItem.rateCents / 100).toFixed(0)}</p>
                                 </>
                               );
                             })()}
@@ -656,24 +703,34 @@ export default function EnhancedProDashboard() {
               {/* Candidate Header */}
               <div className="flex items-center space-x-4">
                 {(() => {
-                  const cand = feedbackModal.candidate || feedbackModal.candidateIdInfo || feedbackModal.candidateId;
+                  const cand =
+                    feedbackModal.candidate ||
+                    feedbackModal.candidateIdInfo ||
+                    feedbackModal.candidateId;
+                  const candObj = typeof cand === 'string' ? undefined : cand;
                   return (
-                    <div className={`w-12 h-12 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                      {cand?.profileImageUrl ? (
-                        <img src={cand.profileImageUrl} alt={cand.name} className="w-12 h-12 rounded-full object-cover" />
+                    <div
+                      className={`w-12 h-12 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}
+                    >
+                      {candObj?.profileImageUrl ? (
+                        <img src={candObj.profileImageUrl} alt={candObj.name} className="w-12 h-12 rounded-full object-cover" />
                       ) : (
-                        cand?.name?.charAt(0) || '?'
+                        candObj?.name?.charAt(0) || (typeof cand === 'string' ? cand.charAt(0) : '?')
                       )}
                     </div>
                   );
                 })()}
                 <div>
                   {(() => {
-                    const cand = feedbackModal.candidate || feedbackModal.candidateIdInfo || feedbackModal.candidateId;
+                    const cand =
+                      feedbackModal.candidate ||
+                      feedbackModal.candidateIdInfo ||
+                      feedbackModal.candidateId;
+                    const candObj = typeof cand === 'string' ? undefined : cand;
                     return (
                       <>
-                        <h4 className="text-lg font-semibold text-gray-900">{cand?.name || 'Candidate'}</h4>
-                          <p className="text-gray-600">Session on {formatLongDate(feedbackModal.scheduledAt || '')}</p>
+                        <h4 className="text-lg font-semibold text-gray-900">{candObj?.name || (typeof cand === 'string' ? cand : 'Candidate')}</h4>
+                        <p className="text-gray-600">Session on {formatLongDate(feedbackModal.scheduledAt || '')}</p>
                       </>
                     );
                   })()}

--- a/src/components/ui/AvailabilityGrid.tsx
+++ b/src/components/ui/AvailabilityGrid.tsx
@@ -30,7 +30,12 @@ interface Props {
   onChange?: (slots: Set<string>) => void;
 }
 
-type AvailabilityEvent = Event & { id: string };
+type AvailabilityEvent = {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+};
 const locales = {
   'en-US': enUS,
 };


### PR DESCRIPTION
## Summary
- correct union types for professional and candidate sessions
- add runtime type guards when rendering dashboard lists
- define AvailabilityGrid event type
- run TypeScript compile to ensure clean build

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f78d3f5b083258d73bb5c080f78a7