### PR TITLE
Fix build failures so auth route compiles

### DIFF
--- a/src/app/api/sessions/candidate/[id]/route.ts
+++ b/src/app/api/sessions/candidate/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { withAuthAndDB, errorResponse } from '@/lib/api/error-handler';
 import type { Session as AuthSession } from 'next-auth';
-import { getCandidateSessions } from '../route';
+import { getCandidateSessions } from '../handlers';
 
 /**
  * GET /api/sessions/candidate/[id]

--- a/src/app/api/sessions/candidate/handlers.ts
+++ b/src/app/api/sessions/candidate/handlers.ts
@@ -1,0 +1,63 @@
+import { successResponse } from '@/lib/api/error-handler';
+import Session from '@/lib/models/Session';
+import type { Session as AuthSession } from 'next-auth';
+
+export async function getCandidateSessions(session: AuthSession) {
+  const candidateId = session.user.id;
+  const now = new Date();
+
+  const upcomingSessions = await Session.find({
+    candidateId,
+    scheduledAt: { $gte: now },
+    status: 'confirmed'
+  })
+    .populate('professionalId', 'name title company profileImageUrl')
+    .sort({ scheduledAt: 1 })
+    .lean();
+
+  const completedSessions = await Session.find({
+    candidateId,
+    $or: [
+      { status: 'completed' },
+      { status: 'confirmed', scheduledAt: { $lt: now } }
+    ]
+  })
+    .populate('professionalId', 'name title company profileImageUrl')
+    .sort({ scheduledAt: -1 })
+    .limit(50)
+    .lean();
+
+  const pendingSessions = await Session.find({ candidateId, status: 'requested' })
+    .populate('professionalId', 'name title company profileImageUrl')
+    .sort({ createdAt: 1 })
+    .lean();
+
+  const monthlySpending = await calculateMonthlySpending(candidateId);
+
+  return successResponse({
+    upcoming: upcomingSessions,
+    completed: completedSessions,
+    pending: pendingSessions,
+    stats: {
+      totalUpcoming: upcomingSessions.length,
+      totalCompleted: completedSessions.length,
+      totalPending: pendingSessions.length,
+      totalSpentThisMonth: monthlySpending
+    }
+  });
+}
+
+async function calculateMonthlySpending(candidateId: string): Promise<number> {
+  const now = new Date();
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+  const paidSessions = await Session.find({
+    candidateId,
+    status: { $in: ['confirmed', 'completed'] },
+    paidAt: { $gte: startOfMonth, $lte: endOfMonth }
+  }).select('rateCents');
+
+  const totalCents = paidSessions.reduce((sum, session) => sum + session.rateCents, 0);
+  return Math.round(totalCents / 100);
+}

--- a/src/app/api/sessions/candidate/route.ts
+++ b/src/app/api/sessions/candidate/route.ts
@@ -1,74 +1,14 @@
 import { NextRequest } from 'next/server';
-import { withAuthAndDB, successResponse } from '@/lib/api/error-handler';
-import Session from '@/lib/models/Session';
+import { withAuthAndDB } from '@/lib/api/error-handler';
 import type { Session as AuthSession } from 'next-auth';
+import { getCandidateSessions } from './handlers';
 
 /**
  * GET /api/sessions/candidate
  * Fetch all sessions for the currently authenticated candidate
  */
-export async function getCandidateSessions(session: AuthSession) {
-  const candidateId = session.user.id;
-  const now = new Date();
-
-  const upcomingSessions = await Session.find({
-    candidateId,
-    scheduledAt: { $gte: now },
-    status: 'confirmed'
-  })
-    .populate('professionalId', 'name title company profileImageUrl')
-    .sort({ scheduledAt: 1 })
-    .lean();
-
-  const completedSessions = await Session.find({
-    candidateId,
-    $or: [
-      { status: 'completed' },
-      { status: 'confirmed', scheduledAt: { $lt: now } }
-    ]
-  })
-    .populate('professionalId', 'name title company profileImageUrl')
-    .sort({ scheduledAt: -1 })
-    .limit(50)
-    .lean();
-
-  const pendingSessions = await Session.find({ candidateId, status: 'requested' })
-    .populate('professionalId', 'name title company profileImageUrl')
-    .sort({ createdAt: 1 })
-    .lean();
-
-  const monthlySpending = await calculateMonthlySpending(candidateId);
-
-  return successResponse({
-    upcoming: upcomingSessions,
-    completed: completedSessions,
-    pending: pendingSessions,
-    stats: {
-      totalUpcoming: upcomingSessions.length,
-      totalCompleted: completedSessions.length,
-      totalPending: pendingSessions.length,
-      totalSpentThisMonth: monthlySpending
-    }
-  });
-}
-
 export const GET = withAuthAndDB(
   async (_req: NextRequest, _ctx: unknown, session: AuthSession) =>
     getCandidateSessions(session),
   { requireRole: 'candidate' }
 );
-
-async function calculateMonthlySpending(candidateId: string): Promise<number> {
-  const now = new Date();
-  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-  const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-
-  const paidSessions = await Session.find({
-    candidateId,
-    status: { $in: ['confirmed', 'completed'] },
-    paidAt: { $gte: startOfMonth, $lte: endOfMonth }
-  }).select('rateCents');
-
-  const totalCents = paidSessions.reduce((sum, session) => sum + session.rateCents, 0);
-  return Math.round(totalCents / 100);
-}

--- a/src/app/components/EnhancedCandidateDashboard.tsx
+++ b/src/app/components/EnhancedCandidateDashboard.tsx
@@ -26,7 +26,7 @@ interface Professional {
 
 interface Session {
   _id: string;
-  professionalId: string;
+  professionalId: string | Professional;
   scheduledAt: string;
   durationMinutes: number;
   rateCents: number;
@@ -297,23 +297,43 @@ export default function EnhancedCandidateDashboard() {
                     <div key={sessionItem._id} className="px-6 py-3 hover:bg-gray-50 transition-colors">
                       <div className="flex items-center space-x-4">
                         {(() => {
-                          const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                          const pro =
+                            (sessionItem.professional ||
+                              sessionItem.professionalId ||
+                              sessionItem.professionalIdInfo) as
+                              string | Professional | undefined;
+                          const hasImage =
+                            typeof pro !== 'string' && !!pro?.profileImageUrl;
+                          const displayName =
+                            typeof pro === 'string'
+                              ? pro
+                              : pro?.name || '';
                           return (
                             <div className={`w-10 h-10 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                              {pro?.profileImageUrl ? (
-                                <img src={pro.profileImageUrl} alt={pro.name} className="w-10 h-10 rounded-full object-cover" />
+                              {hasImage ? (
+                                <img
+                                  src={(pro as Professional).profileImageUrl!}
+                                  alt={displayName}
+                                  className="w-10 h-10 rounded-full object-cover"
+                                />
                               ) : (
-                                pro?.name?.charAt(0) || '?'
+                                displayName.charAt(0) || '?'
                               )}
                             </div>
                           );
                         })()}
                         <div>
                           {(() => {
-                            const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                            const pro =
+                              (sessionItem.professional ||
+                                sessionItem.professionalId ||
+                                sessionItem.professionalIdInfo) as
+                                string | Professional | undefined;
+                            const displayName =
+                              typeof pro === 'string' ? pro : pro?.name || 'Unknown';
                             return (
                               <>
-                                <h4 className="font-medium text-gray-900 text-sm">{pro?.name || 'Unknown'}</h4>
+                                <h4 className="font-medium text-gray-900 text-sm">{displayName}</h4>
                                 <p className="text-xs text-gray-600">{formatDate(sessionItem.scheduledAt)}</p>
                               </>
                             );
@@ -352,17 +372,27 @@ export default function EnhancedCandidateDashboard() {
                       <div className="flex items-center justify-between">
                         <div className="flex items-center space-x-4">
                           {(() => {
-                            const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                            const pro =
+                              (sessionItem.professional ||
+                                sessionItem.professionalId ||
+                                sessionItem.professionalIdInfo) as
+                                string | Professional | undefined;
+                            const hasImage =
+                              typeof pro !== 'string' && !!pro?.profileImageUrl;
+                            const displayName =
+                              typeof pro === 'string'
+                                ? pro
+                                : pro?.name || '';
                             return (
                               <div className={`w-12 h-12 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                                {pro?.profileImageUrl ? (
+                                {hasImage ? (
                                   <img
-                                    src={pro.profileImageUrl}
-                                    alt={pro.name}
+                                    src={(pro as Professional).profileImageUrl!}
+                                    alt={displayName}
                                     className="w-12 h-12 rounded-full object-cover"
                                   />
                                 ) : (
-                                  pro?.name?.charAt(0) || '?'
+                                  displayName.charAt(0) || '?'
                                 )}
                               </div>
                             );
@@ -370,15 +400,21 @@ export default function EnhancedCandidateDashboard() {
 
                           <div>
                             {(() => {
-                              const pro = sessionItem.professional || sessionItem.professionalId || sessionItem.professionalIdInfo;
+                              const pro =
+                                (sessionItem.professional ||
+                                  sessionItem.professionalId ||
+                                  sessionItem.professionalIdInfo) as
+                                  string | Professional | undefined;
+                              const displayName =
+                                typeof pro === 'string' ? pro : pro?.name || 'Unknown';
+                              const titleCompany =
+                                typeof pro === 'string'
+                                  ? ''
+                                  : `${pro?.title || ''} at ${pro?.company || ''}`;
                               return (
                                 <>
-                                  <h3 className="font-bold text-gray-900">
-                                    {pro?.name || 'Unknown'}
-                                  </h3>
-                                  <p className="text-sm text-gray-600">
-                                    {pro?.title} at {pro?.company}
-                                  </p>
+                                  <h3 className="font-bold text-gray-900">{displayName}</h3>
+                                  <p className="text-sm text-gray-600">{titleCompany}</p>
                                 </>
                               );
                             })()}

--- a/src/app/components/EnhancedProDashboard.tsx
+++ b/src/app/components/EnhancedProDashboard.tsx
@@ -11,27 +11,33 @@ import AvailabilityGrid from '@/components/ui/AvailabilityGrid';
 
 interface Session {
   _id: string;
-  candidateId: string;
+  candidateId: string | { _id: string };
   scheduledAt?: string;
   durationMinutes: number;
   rateCents: number;
   status: 'requested' | 'confirmed' | 'completed' | 'cancelled';
   zoomJoinUrl?: string;
   candidateAvailability?: { start: string; end: string }[];
-  candidate?: {
-    name: string;
-    email: string;
-    targetRole?: string;
-    targetIndustry?: string;
-    profileImageUrl?: string;
-  } | string;
-  candidateIdInfo?: {
-    name: string;
-    email: string;
-    targetRole?: string;
-    targetIndustry?: string;
-    profileImageUrl?: string;
-  } | string;
+  candidate?:
+    | string
+    | { _id: string }
+    | {
+        name: string;
+        email: string;
+        targetRole?: string;
+        targetIndustry?: string;
+        profileImageUrl?: string;
+      };
+  candidateIdInfo?:
+    | string
+    | { _id: string }
+    | {
+        name: string;
+        email: string;
+        targetRole?: string;
+        targetIndustry?: string;
+        profileImageUrl?: string;
+      };
   feedbackSubmittedAt?: string;
   referrerProId?: string;
 }
@@ -101,7 +107,10 @@ export default function EnhancedProDashboard() {
             ...s,
             candidate: s.candidate || s.candidateId,
             candidateIdInfo: s.candidateId,
-            candidateId: typeof s.candidateId === 'string' ? s.candidateId : s.candidateId?._id,
+            candidateId:
+              typeof s.candidateId === 'string'
+                ? s.candidateId
+                : (s.candidateId as { _id: string })._id,
           }));
 
         const normUpcoming = normalize(upcoming);
@@ -241,27 +250,41 @@ export default function EnhancedProDashboard() {
                       <div className="flex justify-between items-center">
                         <div className="flex items-center space-x-3">
                         {(() => {
-                          const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                          const cand =
+                            (sessionItem.candidate ||
+                              sessionItem.candidateId ||
+                              sessionItem.candidateIdInfo) as
+                              string | { name?: string; profileImageUrl?: string } | undefined;
+                          const hasImage =
+                            typeof cand !== 'string' && !!cand?.profileImageUrl;
+                          const displayName =
+                            typeof cand === 'string' ? cand : cand?.name || '';
                           return (
                             <div className={`w-10 h-10 ${getAvatarGradient(index)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                              {cand?.profileImageUrl ? (
+                              {hasImage ? (
                                 <img
-                                  src={cand.profileImageUrl}
-                                  alt={cand.name}
+                                  src={(cand as { profileImageUrl: string }).profileImageUrl}
+                                  alt={displayName}
                                   className="w-10 h-10 rounded-full object-cover"
                                 />
                               ) : (
-                                cand?.name?.charAt(0) || '?'
+                                displayName.charAt(0) || '?'
                               )}
                             </div>
                           );
                         })()}
                         <div>
                           {(() => {
-                            const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                            const cand =
+                              (sessionItem.candidate ||
+                                sessionItem.candidateId ||
+                                sessionItem.candidateIdInfo) as
+                                string | { name?: string } | undefined;
+                            const displayName =
+                              typeof cand === 'string' ? cand : cand?.name || 'Unknown';
                             return (
                               <>
-                                <h3 className="font-semibold text-gray-900">{cand?.name || 'Unknown'}</h3>
+                                <h3 className="font-semibold text-gray-900">{displayName}</h3>
                                 <p className="text-sm text-gray-600">{formatDate(sessionItem.scheduledAt || '')}</p>
                               </>
                             );
@@ -331,23 +354,41 @@ export default function EnhancedProDashboard() {
                         <div className="flex justify-between items-center">
                           <div className="flex items-center space-x-3">
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                (sessionItem.candidate ||
+                                  sessionItem.candidateId ||
+                                  sessionItem.candidateIdInfo) as
+                                  string | { name?: string; profileImageUrl?: string } | undefined;
+                              const hasImage =
+                                typeof cand !== 'string' && !!cand?.profileImageUrl;
+                              const displayName =
+                                typeof cand === 'string' ? cand : cand?.name || '';
                               return (
                                 <div className={`w-8 h-8 ${getAvatarGradient(index + 1)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                  {cand?.profileImageUrl ? (
-                                    <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                                  {hasImage ? (
+                                    <img
+                                      src={(cand as { profileImageUrl: string }).profileImageUrl}
+                                      alt={displayName}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
                                   ) : (
-                                    cand?.name?.charAt(0) || '?'
+                                    displayName.charAt(0) || '?'
                                   )}
                                 </div>
                               );
                             })()}
                             <div>
                               {(() => {
-                                const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                                const cand =
+                                  (sessionItem.candidate ||
+                                    sessionItem.candidateId ||
+                                    sessionItem.candidateIdInfo) as
+                                    string | { name?: string } | undefined;
+                                const displayName =
+                                  typeof cand === 'string' ? cand : cand?.name || 'Unknown';
                                 return (
                                   <>
-                                    <h4 className="font-medium text-gray-900 text-sm">{cand?.name || 'Unknown'}</h4>
+                                    <h4 className="font-medium text-gray-900 text-sm">{displayName}</h4>
                                     <p className="text-xs text-gray-600">{formatDate(sessionItem.scheduledAt || '')}</p>
                                   </>
                                 );
@@ -383,23 +424,41 @@ export default function EnhancedProDashboard() {
                         <div className="flex justify-between items-center">
                           <div className="flex items-center space-x-3">
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                (sessionItem.candidate ||
+                                  sessionItem.candidateId ||
+                                  sessionItem.candidateIdInfo) as
+                                  string | { name?: string; profileImageUrl?: string } | undefined;
+                              const hasImage =
+                                typeof cand !== 'string' && !!cand?.profileImageUrl;
+                              const displayName =
+                                typeof cand === 'string' ? cand : cand?.name || '';
                               return (
                                 <div className={`w-8 h-8 ${getAvatarGradient(index + 2)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                  {cand?.profileImageUrl ? (
-                                    <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                                  {hasImage ? (
+                                    <img
+                                      src={(cand as { profileImageUrl: string }).profileImageUrl}
+                                      alt={displayName}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
                                   ) : (
-                                    cand?.name?.charAt(0) || '?'
+                                    displayName.charAt(0) || '?'
                                   )}
                                 </div>
                               );
                             })()}
                             <div>
                               {(() => {
-                                const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                                const cand =
+                                  (sessionItem.candidate ||
+                                    sessionItem.candidateId ||
+                                    sessionItem.candidateIdInfo) as
+                                    string | { name?: string } | undefined;
+                                const displayName =
+                                  typeof cand === 'string' ? cand : cand?.name || 'Unknown';
                                 return (
                                   <>
-                                    <h4 className="font-medium text-gray-900 text-sm">{cand?.name || 'Unknown'}</h4>
+                                    <h4 className="font-medium text-gray-900 text-sm">{displayName}</h4>
                                     <p className="text-xs text-gray-600">Referred • {formatDate(sessionItem.scheduledAt || '', false)}</p>
                                   </>
                                 );
@@ -475,23 +534,41 @@ export default function EnhancedProDashboard() {
                       <div className="flex justify-between items-center">
                         <div className="flex items-center space-x-3">
                           {(() => {
-                            const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                            const cand =
+                              (sessionItem.candidate ||
+                                sessionItem.candidateId ||
+                                sessionItem.candidateIdInfo) as
+                                string | { name?: string; profileImageUrl?: string } | undefined;
+                            const hasImage =
+                              typeof cand !== 'string' && !!cand?.profileImageUrl;
+                            const displayName =
+                              typeof cand === 'string' ? cand : cand?.name || '';
                             return (
                               <div className={`w-8 h-8 ${getAvatarGradient(index + 3)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                {cand?.profileImageUrl ? (
-                                  <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                                {hasImage ? (
+                                  <img
+                                    src={(cand as { profileImageUrl: string }).profileImageUrl}
+                                    alt={displayName}
+                                    className="w-8 h-8 rounded-full object-cover"
+                                  />
                                 ) : (
-                                  cand?.name?.charAt(0) || '?'
+                                  displayName.charAt(0) || '?'
                                 )}
                               </div>
                             );
                           })()}
                           <div>
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                (sessionItem.candidate ||
+                                  sessionItem.candidateId ||
+                                  sessionItem.candidateIdInfo) as
+                                  string | { name?: string } | undefined;
+                              const displayName =
+                                typeof cand === 'string' ? cand : cand?.name || 'Unknown';
                               return (
                                 <>
-                                  <h4 className="font-medium text-gray-900">{cand?.name || 'Unknown'}</h4>
+                                  <h4 className="font-medium text-gray-900">{displayName}</h4>
                                   <p className="text-sm text-gray-600">{formatDate(sessionItem.scheduledAt || '', false)}</p>
                                 </>
                               );
@@ -527,23 +604,41 @@ export default function EnhancedProDashboard() {
                       <div className="flex justify-between items-center">
                         <div className="flex items-center space-x-3">
                           {(() => {
-                            const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                            const cand =
+                              (sessionItem.candidate ||
+                                sessionItem.candidateId ||
+                                sessionItem.candidateIdInfo) as
+                                string | { name?: string; profileImageUrl?: string } | undefined;
+                            const hasImage =
+                              typeof cand !== 'string' && !!cand?.profileImageUrl;
+                            const displayName =
+                              typeof cand === 'string' ? cand : cand?.name || '';
                             return (
                               <div className={`w-8 h-8 ${getAvatarGradient(index + 4)} rounded-full flex items-center justify-center text-white font-bold text-sm overflow-hidden`}>
-                                {cand?.profileImageUrl ? (
-                                  <img src={cand.profileImageUrl} alt={cand.name} className="w-8 h-8 rounded-full object-cover" />
+                                {hasImage ? (
+                                  <img
+                                    src={(cand as { profileImageUrl: string }).profileImageUrl}
+                                    alt={displayName}
+                                    className="w-8 h-8 rounded-full object-cover"
+                                  />
                                 ) : (
-                                  cand?.name?.charAt(0) || '?'
+                                  displayName.charAt(0) || '?'
                                 )}
                               </div>
                             );
                           })()}
                           <div>
                             {(() => {
-                              const cand = sessionItem.candidate || sessionItem.candidateId || sessionItem.candidateIdInfo;
+                              const cand =
+                                (sessionItem.candidate ||
+                                  sessionItem.candidateId ||
+                                  sessionItem.candidateIdInfo) as
+                                  string | { name?: string } | undefined;
+                              const displayName =
+                                typeof cand === 'string' ? cand : cand?.name || 'Unknown';
                               return (
                                 <>
-                                  <h4 className="font-medium text-gray-900">{cand?.name || 'Unknown'}</h4>
+                                  <h4 className="font-medium text-gray-900">{displayName}</h4>
                                   <p className="text-sm text-gray-600">{formatDate(sessionItem.scheduledAt || '', false)} • ${(sessionItem.rateCents / 100).toFixed(0)}</p>
                                 </>
                               );
@@ -565,15 +660,21 @@ export default function EnhancedProDashboard() {
       <Modal
         isOpen={!!acceptModal}
         onClose={() => setAcceptModal(null)}
-        title={acceptModal ? `Select Time for ${
-          typeof acceptModal.candidate === 'string'
-            ? acceptModal.candidate
-            : acceptModal.candidate?.name ||
-              (typeof acceptModal.candidateIdInfo === 'string'
-                ? acceptModal.candidateIdInfo
-                : acceptModal.candidateIdInfo?.name) ||
-              'Candidate'
-        }` : ''}
+        title={
+          acceptModal
+            ? `Select Time for ${
+                typeof acceptModal.candidate === 'string'
+                  ? acceptModal.candidate
+                  : (acceptModal.candidate && 'name' in acceptModal.candidate
+                      ? acceptModal.candidate.name
+                      : (typeof acceptModal.candidateIdInfo === 'string'
+                          ? acceptModal.candidateIdInfo
+                          : acceptModal.candidateIdInfo && 'name' in acceptModal.candidateIdInfo
+                          ? acceptModal.candidateIdInfo.name
+                          : undefined)) || 'Candidate'
+              }`
+            : ''
+        }
         subtitle="Choose a time from candidate's availability"
         maxWidth="lg"
         actions={
@@ -618,18 +719,25 @@ export default function EnhancedProDashboard() {
         <Modal
           isOpen={!!feedbackModal}
           onClose={() => setFeedbackModal(null)}
-        title={feedbackModal ? `Submit Feedback for ${
-          typeof feedbackModal.candidate === 'string'
-            ? feedbackModal.candidate
-            : feedbackModal.candidate?.name ||
-              (typeof feedbackModal.candidateIdInfo === 'string'
-                ? feedbackModal.candidateIdInfo
-                : feedbackModal.candidateIdInfo?.name) ||
-              (typeof feedbackModal.candidateId === 'string'
-                ? feedbackModal.candidateId
-                : (feedbackModal.candidateId as { name?: string })?.name) ||
-              'Candidate'
-        }` : ''}
+        title={
+          feedbackModal
+            ? `Submit Feedback for ${
+                typeof feedbackModal.candidate === 'string'
+                  ? feedbackModal.candidate
+                  : (feedbackModal.candidate && 'name' in feedbackModal.candidate
+                      ? feedbackModal.candidate.name
+                      : (typeof feedbackModal.candidateIdInfo === 'string'
+                          ? feedbackModal.candidateIdInfo
+                          : feedbackModal.candidateIdInfo && 'name' in feedbackModal.candidateIdInfo
+                          ? feedbackModal.candidateIdInfo.name
+                          : undefined)) ||
+                    (typeof feedbackModal.candidateId === 'string'
+                      ? feedbackModal.candidateId
+                      : (feedbackModal.candidateId as { name?: string })?.name) ||
+                    'Candidate'
+              }`
+            : ''
+        }
         subtitle={feedbackModal ? `Session on ${formatLongDate(feedbackModal.scheduledAt || '')}` : ''}
           maxWidth="3xl"
           actions={
@@ -656,24 +764,46 @@ export default function EnhancedProDashboard() {
               {/* Candidate Header */}
               <div className="flex items-center space-x-4">
                 {(() => {
-                  const cand = feedbackModal.candidate || feedbackModal.candidateIdInfo || feedbackModal.candidateId;
+                  const cand =
+                    (feedbackModal.candidate ||
+                      feedbackModal.candidateIdInfo ||
+                      feedbackModal.candidateId) as
+                      string | { _id: string } | { name?: string; profileImageUrl?: string } | undefined;
+                  const hasImage =
+                    typeof cand !== 'string' && cand && 'profileImageUrl' in cand && !!cand.profileImageUrl;
+                  const displayName =
+                    typeof cand === 'string'
+                      ? cand
+                      : cand && 'name' in cand
+                      ? cand.name || ''
+                      : '';
                   return (
                     <div className={`w-12 h-12 ${getAvatarGradient(0)} rounded-full flex items-center justify-center text-white font-bold overflow-hidden`}>
-                      {cand?.profileImageUrl ? (
-                        <img src={cand.profileImageUrl} alt={cand.name} className="w-12 h-12 rounded-full object-cover" />
+                      {hasImage ? (
+                        <img src={(cand as { profileImageUrl: string }).profileImageUrl} alt={displayName} className="w-12 h-12 rounded-full object-cover" />
                       ) : (
-                        cand?.name?.charAt(0) || '?'
+                        displayName.charAt(0) || '?'
                       )}
                     </div>
                   );
                 })()}
                 <div>
                   {(() => {
-                    const cand = feedbackModal.candidate || feedbackModal.candidateIdInfo || feedbackModal.candidateId;
+                    const cand =
+                      (feedbackModal.candidate ||
+                        feedbackModal.candidateIdInfo ||
+                        feedbackModal.candidateId) as
+                        string | { _id: string } | { name?: string } | undefined;
+                    const displayName =
+                      typeof cand === 'string'
+                        ? cand
+                        : cand && 'name' in cand
+                        ? cand.name || 'Candidate'
+                        : 'Candidate';
                     return (
                       <>
-                        <h4 className="text-lg font-semibold text-gray-900">{cand?.name || 'Candidate'}</h4>
-                          <p className="text-gray-600">Session on {formatLongDate(feedbackModal.scheduledAt || '')}</p>
+                        <h4 className="text-lg font-semibold text-gray-900">{displayName}</h4>
+                        <p className="text-gray-600">Session on {formatLongDate(feedbackModal.scheduledAt || '')}</p>
                       </>
                     );
                   })()}

--- a/src/components/ui/AvailabilityGrid.tsx
+++ b/src/components/ui/AvailabilityGrid.tsx
@@ -77,7 +77,7 @@ export default function AvailabilityGrid({ startDate, days, initialSelected, onC
     }
 
     setEvents(next);
-    onChange?.(new Set(next.map((e) => e.start.toISOString())));
+    onChange?.(new Set(next.map((e) => e.start!.toISOString())));
   };
 
   const handleNavigate = (date: Date) => {


### PR DESCRIPTION
## Summary
- move `getCandidateSessions` handler into separate file
- use new handler in API route
- make union types for candidate/professional IDs
- handle mixed object/string values in dashboards
- fix AvailabilityGrid event typing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f76e9907c8325ad76e34c11aaed31