### PR TITLE
Fix NextAuth build error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["react-big-calendar"]
+  // Transpile ESM packages that ship uncompiled code
+  transpilePackages: [
+    "react-big-calendar",
+    "next-auth"
+  ]
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- transpile `next-auth` so the vendor chunk is generated

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68500357d9748325ae6ddcf0cf52bc97