### PR TITLE
Fix candidate dashboard session caching

### DIFF
--- a/src/app/api/sessions/candidate/[id]/route.ts
+++ b/src/app/api/sessions/candidate/[id]/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest } from 'next/server';
+
+// Mark this route as dynamic to prevent caching per-user results
+export const dynamic = 'force-dynamic';
 import { withAuthAndDB, errorResponse } from '@/lib/api/error-handler';
 import type { Session as AuthSession } from 'next-auth';
 import { getCandidateSessions } from '@/lib/api/candidate-sessions';

--- a/src/app/api/sessions/candidate/route.ts
+++ b/src/app/api/sessions/candidate/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest } from 'next/server';
+
+// Ensure this route is always dynamic and never cached
+export const dynamic = 'force-dynamic';
 import { withAuthAndDB } from '@/lib/api/error-handler';
 import type { Session as AuthSession } from 'next-auth';
 import { getCandidateSessions } from '@/lib/api/candidate-sessions';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -259,6 +259,7 @@ export async function apiRequest<T>(
         ...options.headers,
       },
       credentials: 'include',
+      cache: 'no-store',
       ...options,
     });
 


### PR DESCRIPTION
## Summary
- ensure candidate session API routes are dynamic so results aren't cached
- disable browser caching in the apiRequest helper

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685035cb4fbc8325aaeaf3d1c5f517ed