### PR TITLE
Use NextAuth default redirects

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -2,37 +2,22 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { signIn, getSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { signIn } from "next-auth/react";
 import Navigation from "@/components/ui/Navigation";
 
 export default function SignInPage() {
   const [loading, setLoading] = useState<string | null>(null);
-  const router = useRouter();
 
   const handleSocialSignIn = async (provider: 'google' | 'linkedin') => {
     setLoading(provider);
-    
+
     try {
-      const result = await signIn(provider, { 
-        redirect: false,
-        callbackUrl: '/auth/setup' // Redirect to role selection after OAuth
+      await signIn(provider, {
+        callbackUrl: '/auth/setup'
       });
-      
-      if (result?.ok) {
-        // Check if user needs to complete profile setup
-        const session = await getSession();
-        if (session?.user) {
-          // Redirect based on user role or to setup if new user
-          router.push('/auth/setup');
-        }
-      } else if (result?.error) {
-        alert('Failed to sign in. Please try again.');
-      }
     } catch (error) {
       console.error('Sign in error:', error);
       alert('Failed to sign in. Please try again.');
-    } finally {
       setLoading(null);
     }
   };

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -19,9 +19,7 @@ export default function Navigation({
   const [showUserMenu, setShowUserMenu] = useState(false);
 
   const handleSignOut = async () => {
-    await signOut({ 
-      callbackUrl: '/' 
-    });
+    await signOut();
   };
 
   const renderPublicLinks = () => (


### PR DESCRIPTION
## Summary
- remove manual sign-in redirects
- rely on automatic sign-out redirect

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850d521768c83259e7e4f16f92524ad