### PR TITLE
fix: add Google freebusy scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ stacks/
 
 ## 🔄 Calendar Integration
 
--### Google Calendar Sync
-- **OAuth scope**: `https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly`
+### Google Calendar Sync
+ - **OAuth scope**: `https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.freebusy`
 - **Free/busy queries** for availability checking
 - **Automatic event creation** for confirmed sessions
 - **Manual availability** editing with override capability

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,7 +11,7 @@ export const authOptions: NextAuthOptions = {
       authorization: {
         params: {
           scope:
-            'openid email profile https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly'
+            'openid email profile https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.freebusy'
         }
       }
     }),


### PR DESCRIPTION
## Summary
- include `calendar.freebusy` scope for Google OAuth
- document the new Google Calendar scope
- clean up heading in docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854047a375083258d33f6784f5e24b4